### PR TITLE
Feature/include lat lng in callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"path_provider","dependencies":[]},{"name":"sqflite","dependencies":[]}]}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -85,7 +85,7 @@ class _HomePageState extends State<HomePage> {
         point: LatLng(49.8566, 3.3522),
         builder: (ctx) => Icon(Icons.pin_drop),
       ),
-     ];
+    ];
 
     super.initState();
   }
@@ -102,7 +102,8 @@ class _HomePageState extends State<HomePage> {
           }
           setState(() {
             markers[0] = MarkerData<String>(
-              data: "${points[pointIndex].latitude}, ${points[pointIndex].longitude}",
+              data:
+                  "${points[pointIndex].latitude}, ${points[pointIndex].longitude}",
               point: points[pointIndex],
               anchorPos: AnchorPos.align(AnchorAlign.center),
               height: 30,
@@ -131,7 +132,8 @@ class _HomePageState extends State<HomePage> {
             subdomains: ['a', 'b', 'c'],
           ),
           MarkerClusterLayerOptions(
-            markerSelected: (context, marker) => _markerSelected(context, marker),            
+            markerSelected: (context, marker, point) =>
+                _markerSelected(context, marker),
             maxClusterRadius: 120,
             size: Size(40, 40),
             anchor: AnchorPos.align(AnchorAlign.center),
@@ -143,7 +145,7 @@ class _HomePageState extends State<HomePage> {
                 borderColor: Colors.blueAccent,
                 color: Colors.black12,
                 borderStrokeWidth: 3),
-            builder: (context, markers) {
+            builder: (context, markers, point) {
               return FloatingActionButton(
                 child: Text(markers.length.toString()),
                 onPressed: null,
@@ -154,6 +156,7 @@ class _HomePageState extends State<HomePage> {
       ),
     );
   }
+
   void _markerSelected(BuildContext context, MarkerData<String> marker) {
     //final record = recordMap[marker.point];
     final data = marker.data;

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -317,8 +317,11 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: _onClusterTap(cluster),
-        child: widget.options
-            .builder(context, getClusterMarkers(cluster), cluster.point),
+        child: widget.options.builder(
+          context,
+          getClusterMarkers(cluster),
+          cluster.point,
+        ),
       ),
       builder: (BuildContext context, Widget child) {
         return Positioned(

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -256,6 +256,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           child: widget.options.builder(
             context,
             cluster.markers.map((node) => node.marker).toList(),
+            cluster.point,
           ),
         ),
         builder: (BuildContext context, Widget child) {
@@ -316,10 +317,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: _onClusterTap(cluster),
-        child: widget.options.builder(
-          context,
-          getClusterMarkers(cluster),
-        ),
+        child: widget.options
+            .builder(context, getClusterMarkers(cluster), cluster.point),
       ),
       builder: (BuildContext context, Widget child) {
         return Positioned(
@@ -599,7 +598,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           _fitBoundController.isAnimating) return null;
 
       if (widget.options.markerSelected != null && marker.child != null) {
-        widget.options.markerSelected(context, marker.child);
+        widget.options.markerSelected(context, marker.child, marker.point);
       }
 
       if (!widget.options.centerMarkerOnClick) return null;

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_marker_cluster/src/marker_cluster_data_node.dart';
+import 'package:latlong/latlong.dart';
 
 class PolygonOptions {
   final Color color;
@@ -20,10 +21,10 @@ class PolygonOptions {
 }
 
 typedef ClusterWidgetBuilder = Widget Function(
-    BuildContext context, List<MarkerData<dynamic>> markers);
+    BuildContext context, List<Marker> markers, LatLng point);
 
-typedef MarkerSelectedCallback = void Function(BuildContext context, MarkerData<dynamic> marker);
-
+typedef MarkerSelectedCallback = void Function(
+    BuildContext context, MarkerData<dynamic> marker, LatLng point);
 
 class MarkerClusterLayerOptions extends LayerOptions {
   /// Cluster builder


### PR DESCRIPTION
Imagine that you _double-tap_ on your map - it will zoom in based on the location that you tapped.

Now imagine that you _double-tap_ on one of the _clusters_  (`FloatingActionBar`) - from which location do you zoom from? The only information that you easily have at your disposal is `Mapcontroller.center`, which won't give the desired result.

This pull request modifies the `MarkerClusterLayerOptions` so that the location is returned in the `builder` function. This allows the location to be passed down into the `FloatingActionBar` so that when it is _double-tapped_ it will know which location to zoom from.